### PR TITLE
Fix wrong circumscribed threshold computation.

### DIFF
--- a/src/sbpl_lattice_planner.cpp
+++ b/src/sbpl_lattice_planner.cpp
@@ -134,7 +134,7 @@ void SBPLLatticePlanner::initialize(std::string name, costmap_2d::Costmap2DROS* 
       boost::shared_ptr<costmap_2d::InflationLayer> inflation_layer = boost::dynamic_pointer_cast<costmap_2d::InflationLayer>(*layer);
       if (!inflation_layer) continue;
 
-      cost_possibly_circumscribed_tresh = inflation_layer->computeCost(costmap_ros_->getLayeredCostmap()->getCircumscribedRadius());
+      cost_possibly_circumscribed_tresh = inflation_layer->computeCost(costmap_ros_->getLayeredCostmap()->getCircumscribedRadius()/costmap_ros_->getCostmap()->getResolution());
     }
 
     if(!env_->SetEnvParameter("cost_inscribed_thresh",costMapCostToSBPLCost(costmap_2d::INSCRIBED_INFLATED_OBSTACLE))){


### PR DESCRIPTION
`computeCost` here takes distances in cells, while `getCircumscribedRadius` returns meters.